### PR TITLE
Fix config saving with runtime data (fixes gray screen bug) and refunds on currencies with decimal support

### DIFF
--- a/components/ConfigEditor.lua
+++ b/components/ConfigEditor.lua
@@ -660,13 +660,14 @@ return Solyd.wrapComponent("ConfigEditor", function(props)
             borderColor = theme.modalBorderColor,
             onConfirm = function()
                 local newConfig = configHelpers.getNewConfig(props.config, configDiffs, arrayAdds, arrayRemoves)
+                local newEditConfig = configHelpers.getNewConfig(props.editConfig, configDiffs, arrayAdds, arrayRemoves)
                 setSaveModalOpen(false)
                 setArrayAdds({})
                 setArrayRemoves({})
                 setConfigDiffs({})
                 setUpdates(updates + 1)
                 if props.onSave then
-                    props.onSave(newConfig)
+                    props.onSave(newConfig, newEditConfig)
                 end
             end,
             onCancel = function()

--- a/config.lua
+++ b/config.lua
@@ -233,6 +233,17 @@ return {
     },
     currencies = {
         {
+            id = "kromer", -- if not krist or tenebra, must supply endpoint
+            -- node = "https://kromer.reconnected.cc/api/krist/",
+            host = nil, -- Your krist address (only if using nameless shop, example: 'k123456789')
+            name = nil, -- Your krist name, usually ending in .kst (only if using krist name)
+            pkey = nil, -- Your private key, or password for kristwallet
+            pkeyFormat = "raw", -- Currently must be 'raw' or 'kristwallet'
+            -- You can get your raw pkey from kristweb or using https://pkey.its-em.ma/
+            value = 1.0, -- Default scaling on item prices, can be overridden on a per-item basis
+            -- minimumIncrement = 0.01, -- Minimum increment for this currency, used to determine the minimum refundabe amount (this is automatically determined by id here)
+        },
+        --[[{
             id = "krist", -- if not krist or tenebra, must supply endpoint
             -- node = "https://krist.dev/"
             host = nil, -- Your krist address (only if using nameless shop, example: 'k123456789')
@@ -240,8 +251,9 @@ return {
             pkey = nil, -- Your private key, or password for kristwallet
             pkeyFormat = "raw", -- Currently must be 'raw' or 'kristwallet'
             -- You can get your raw pkey from kristweb or using https://pkey.its-em.ma/
-            value = 1.0 -- Default scaling on item prices, can be overridden on a per-item basis
-        },
+            value = 1.0, -- Default scaling on item prices, can be overridden on a per-item basis
+            -- minimumIncrement = 1, -- Minimum increment for this currency, used to determine the minimum refundabe amount (this is automatically determined by id here)
+        },]]
         --[[{
             id = "tenebra", -- if not krist or tenebra, must supply endpoint
             -- node = "https://krist.dev/"
@@ -250,7 +262,8 @@ return {
             pkey = nil, -- Your private key, or password for kristwallet
             pkeyFormat = "raw", -- Currently must be 'raw', kwallet support is planned
             -- You can get your raw pkey from kristweb or using https://pkey.its-em.ma/
-            value = 0.1 -- Default scaling on item prices, can be overridden on a per-item basis
+            value = 0.1, -- Default scaling on item prices, can be overridden on a per-item basis
+            -- minimumIncrement = 1, -- Minimum increment for this currency, used to determine the minimum refundabe amount (this is automatically determined by id here)
         },--]]
         --[[{
             id = "carrotpay", -- defaults to krist endpoint + carrotpay.herrkatze.com for name resolution
@@ -260,7 +273,8 @@ return {
             pkey = nil, -- Your private key, or password for kristwallet
             pkeyFormat = "raw", -- Currently must be 'raw', kwallet support is planned
             -- You can get your raw pkey from kristweb or using https://pkey.its-em.ma/
-            value = 0.1 -- Default scaling on item prices, can be overridden on a per-item basis
+            value = 0.1, -- Default scaling on item prices, can be overridden on a per-item basis
+            -- minimumIncrement = 1, -- Minimum increment for this currency, used to determine the minimum refundabe amount (this is automatically determined by id here)
         },--]]
     },
     shopSync = {

--- a/core/ShopState.lua
+++ b/core/ShopState.lua
@@ -229,7 +229,10 @@ function ShopState:handlePurchase(transaction, meta, sentMetaname, transactionCu
         return
     end
 
-    local refundAmount = math.floor(transaction.value - (available * productPrice))
+    local currencyMinimumIncrement = transactionCurrency.minimumIncrement or 1
+    local refundAmountRaw = transaction.value - (available * productPrice)
+    local refundAmount = math.floor(refundAmountRaw / currencyMinimumIncrement) * currencyMinimumIncrement
+
     local allowPurchase = true
     local err
     local errMessage
@@ -323,11 +326,18 @@ function ShopState:setupKrypton()
             currency.name = nil
         end
         local node = currency.node
-        if not node and (currency.id == "krist" or currency.id == "carrotpay") then
-            node = "https://krist.dev/"
-        elseif not node and currency.id == "tenebra" then
-            node = "https://tenebra.lil.gay/"
+
+        if currency.id == "krist" or currency.id == "carrotpay" then
+            node = node or "https://krist.dev/"
+            currency.minimumIncrement = currency.minimumIncrement or 1
+        elseif currency.id == "tenebra" then
+            node = node or "https://tenebra.lil.gay/"
+            currency.minimumIncrement = currency.minimumIncrement or 1
+        elseif currency.id == "kromer" then
+            node = node or "https://kromer.reconnected.cc/api/krist/"
+            currency.minimumIncrement = currency.minimumIncrement or 0.01
         end
+        
         currency.krypton = Krypton.new({
             privateKey = currency.pkey,
             node = node,

--- a/radon.lua
+++ b/radon.lua
@@ -219,7 +219,7 @@ local Terminal = Solyd.wrapComponent("Terminal", function(props)
     local theme = props.configState.config.terminalTheme
 
     local flatCanvas = {}
-    local versionString = "Radon " .. version
+    local versionString = version
     local terminalCatagories = { "logs", "config", "products" }
     local bodyHeight = math.floor(terminal.bgCanvas.height / 3) - 1
     local bodyWidth = math.floor(terminal.bgCanvas.width / 2)

--- a/radon.lua
+++ b/radon.lua
@@ -25,6 +25,7 @@ end
 
 --- Imports
 local _ = require("util.score")
+local misc = require("util.misc")
 local sound = require("util.sound")
 local eventHook = require("util.eventHook")
 
@@ -57,8 +58,8 @@ local defaultLayout = require("DefaultLayout")
 local loadRIF = require("modules.rif")
 
 local configDefaults = require("configDefaults")
-local config = require("config")
-local products = require("products")
+local config = misc.plainDeepCopy(require("config"))
+local products = misc.plainDeepCopy(require("products"))
 local eventHooks = {}
 if fs.exists(fs.combine(fs.getDir(shell.getRunningProgram()), "eventHooks.lua")) then
     eventHooks = require("eventHooks")
@@ -66,6 +67,11 @@ end
 --- End Imports
 
 configHelpers.loadDefaults(config, configDefaults)
+
+-- these are for the GUI config editor, so that it doesnt save runtime stuff
+local editConfig = misc.plainDeepCopy(config)
+local editProducts = misc.plainDeepCopy(products)
+
 local configErrors = ConfigValidator.validateConfig(config)
 local productsErrors = ConfigValidator.validateProducts(products)
 
@@ -93,6 +99,8 @@ local configState = {
     config = config,
     products = products,
     eventHooks = eventHooks,
+    editConfig = editConfig,
+    editProducts = editProducts,
 }
 
 local Main = Solyd.wrapComponent("Main", function(props)
@@ -273,15 +281,17 @@ local Terminal = Solyd.wrapComponent("Terminal", function(props)
             width = bodyWidth,
             height = bodyHeight,
             config = props.configState.config,
+            editConfig = props.configState.editConfig,
             schema = schemas.configSchema,
             errors = props.terminalState.configErrors,
             errorPrefix = "config",
             terminalState = props.terminalState,
             theme = theme.colors.configEditor,
-            onSave = function(newConfig)
+            onSave = function(newConfig, newEditConfig)
                 props.shopState.oldConfig = props.configState.config
                 props.shopState.config = newConfig
                 props.configState.config = newConfig
+                props.configState.editConfig = newEditConfig
                 props.terminalState.configErrors = ConfigValidator.validateConfig(newConfig)
                 if (not props.terminalState.configErrors or #props.terminalState.configErrors == 0) and (not props.terminalState.productsErrors or #props.terminalState.productsErrors == 0) then
                     newConfig.ready = true
@@ -289,12 +299,13 @@ local Terminal = Solyd.wrapComponent("Terminal", function(props)
                 configHelpers.getPeripherals(newConfig, peripherals)
                 -- TODO: Detect if we actually need to update currencies
                 props.shopState.changedCurrencies = true
+                local serialized = textutils.serialize(newEditConfig)
                 local f = fs.open("config.lua", "w")
-                f.write("return " .. textutils.serialize(newConfig))
+                f.write("return " .. serialized)
                 f.close()
                 print("Configs updated!")
                 if props.configState.eventHooks and props.configState.eventHooks.configSaved then
-                    props.configState.eventHooks.configSaved(newConfig)
+                    props.configState.eventHooks.configSaved(newEditConfig)
                 end
             end
         })
@@ -312,25 +323,28 @@ local Terminal = Solyd.wrapComponent("Terminal", function(props)
             width = bodyWidth,
             height = bodyHeight,
             config = props.shopState.products,
+            editConfig = props.configState.editProducts,
             schema = schemas.productsSchema,
             errors = props.terminalState.productsErrors,
             errorPrefix = "products",
             terminalState = props.terminalState,
             theme = theme.colors.productsEditor,
-            onSave = function(newConfig)
+            onSave = function(newConfig, newEditConfig)
                 props.shopState.products = newConfig
                 props.configState.products = newConfig
+                props.configState.editProducts = newEditConfig
                 props.terminalState.productsErrors = ConfigValidator.validateProducts(products)
                 if (not props.terminalState.configErrors or #props.terminalState.configErrors == 0) and (not props.terminalState.productsErrors or #props.terminalState.productsErrors == 0) then
                     props.configState.config.ready = true
                 end
                 ScanInventory.clearNbtCache()
+                local serialized = textutils.serialize(newEditConfig)
                 local f = fs.open("products.lua", "w")
-                f.write("return " .. textutils.serialize(newConfig))
+                f.write("return " .. serialized)
                 f.close()
                 print("Products updated!")
                 if props.configState.eventHooks and props.configState.eventHooks.productsSaved then
-                    props.configState.eventHooks.productsSaved(newConfig)
+                    props.configState.eventHooks.productsSaved(newEditConfig)
                 end
             end
         })

--- a/radon.lua
+++ b/radon.lua
@@ -1,4 +1,4 @@
-local version = "1.3.33"
+local version = "1.3.34-katze"
 local configHelpers = require "util.configHelpers"
 local schemas       = require "core.schemas"
 local ScanInventory = require("core.inventory.ScanInventory")

--- a/util/misc.lua
+++ b/util/misc.lua
@@ -37,7 +37,26 @@ function bakeToCanvas(rootComponent)
     return canvas
 end
 
+--Deeply copies a table, not taking into account __opaque and __nocopy
+local function plainDeepCopy(t)
+    if type(t) ~= "table" then
+        return t
+    end
+
+    local copy = {}
+    for k, v in pairs(t) do
+        if type(v) == "table" then
+            copy[k] = plainDeepCopy(v)
+        else
+            copy[k] = v
+        end
+    end
+    return copy
+end
+
+
 return {
     tableSize = tableSize,
     bakeToCanvas = bakeToCanvas,
+    plainDeepCopy = plainDeepCopy
 }


### PR DESCRIPTION
The GUI editor now uses a separate config that's copied before radon writes any runtime data to it, It's the cleanest solution I was able to find that doesn't involve rewriting/editing a lot of stuff. As for the refunds, there is now a `minimumIncrement` field in currencies, which is automatically handled for currencies with ids `kromer`, `krist`, `carrotpay`, `tenebra`.