### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,66 @@
+name: Auto Build
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build_and_release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq libfuse2 libpulse0
+
+      - name: Download CraftOS-PC
+        run: |
+          API_URL="https://api.github.com/repos/MCJack123/craftos2/releases/latest"
+          ASSET_URL=$(curl -s $API_URL \
+            | jq -r '.assets[] | select(.name | test("AppImage")) | .browser_download_url')
+          echo "Downloading AppImage from $ASSET_URL"
+          curl -L -o CraftOS-PC.AppImage "$ASSET_URL"
+          chmod +x CraftOS-PC.AppImage
+          mv CraftOS-PC.AppImage /usr/local/bin/craftos
+
+      - name: Run build.sh
+        run: |
+          chmod +x ./build.sh
+          ./build.sh
+
+      - name: Collect artifacts
+        run: |
+          mkdir artifact
+          cp build/radon.lua artifact/
+          cp config.lua artifact/
+          cp products.lua artifact/
+          cp eventHooks.lua artifact/
+          cp CardLayout.lua artifact/
+          tar -cf release.tar artifact/*
+
+      - name: Upload Build Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          path: artifact/*
+          retention-days: 90
+
+      - name: Create Latest Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: latest
+          name: Latest Build
+          prerelease: true
+          files: |
+            release.tar
+            artifact/radon.lua

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,17 @@
-name: Auto Build
+name: Stable Release
 
 on:
-  push:
-    branches: ["main"]
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version"
+        required: true
 
 permissions:
   contents: write
 
 jobs:
-  build_and_release:
+  release:
     runs-on: ubuntu-latest
 
     steps:
@@ -29,7 +31,6 @@ jobs:
           API_URL="https://api.github.com/repos/MCJack123/craftos2/releases/latest"
           ASSET_URL=$(curl -s $API_URL \
             | jq -r '.assets[] | select(.name | test("AppImage")) | .browser_download_url')
-          echo "Downloading AppImage from $ASSET_URL"
           curl -L -o CraftOS-PC.AppImage "$ASSET_URL"
           chmod +x CraftOS-PC.AppImage
           mv CraftOS-PC.AppImage /usr/local/bin/craftos
@@ -39,7 +40,7 @@ jobs:
           chmod +x ./build.sh
           ./build.sh
 
-      - name: Collect artifacts
+      - name: Create archive
         run: |
           mkdir artifact
           cp build/radon.lua artifact/
@@ -49,18 +50,12 @@ jobs:
           cp CardLayout.lua artifact/
           tar -cf release.tar -C artifact .
 
-      - name: Upload Build Artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          path: artifact/*
-          retention-days: 90
-
-      - name: Create Latest Release
+      - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: latest
-          name: Latest Build
-          prerelease: true
+          tag_name: v${{ github.event.inputs.version }}
+          name: v${{ github.event.inputs.version }}
+          prerelease: false
           files: |
             release.tar
             artifact/radon.lua

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "Krypton"]
 	path = Krypton
 	url = git@github.com:scmcgowen/Krypton.git
+[submodule "howl"]
+	path = howl
+	url = https://github.com/squidDev-CC/howl/

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ For any support needs or feature requests, contact Allymonies. Radon is in activ
 
 # Installation
 
-While you can install Radon with the Howlfile, or just copying all the files to the computer, it is recommended to use the installer, `pastebin run WAXroOQqH` (RePaste https://p.reconnected.cc/WAXroOQqH). This will download the required files, `radon.lua`, `config.lua`, and `products.lua`.
+While you can install Radon with the Howlfile, or just copying all the files to the computer, it is recommended to use the installer, `pastebin run AIvguxFeA` (RePaste https://p.reconnected.cc/AIvguxFeA). This will download the required files, `radon.lua`, `config.lua`, `products.lua`, `eventHooks.lua` and `CardLayout.lua`.
 
 # Setup
 

--- a/build-headless.lua
+++ b/build-headless.lua
@@ -1,0 +1,10 @@
+-- janky
+shell.run("cd howl")
+shell.run("./bootstrap.lua")
+if not fs.exists(shell.resolve("./build/Howl.lua")) then
+    os.shutdown(1)
+end
+shell.run("cd ..")
+shell.run("./howl/build/Howl.lua build")
+
+os.shutdown(0)

--- a/build.lua
+++ b/build.lua
@@ -1,0 +1,6 @@
+-- janky
+shell.run("cd howl")
+shell.run("./bootstrap.lua")
+assert(fs.exists(shell.resolve("./build/Howl.lua")))
+shell.run("cd ..")
+shell.run("./howl/build/Howl.lua build")

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if ! command -v craftos >/dev/null 2>&1; then
+    echo "Error: craftos-pc ('craftos') not found, please install it."
+    exit 1
+fi
+
+timeout 10s craftos --headless --exec "shell.run('ls');shell.run('/build-headless.lua')" -c="$PWD"
+
+if [ $? -eq 124 ]; then
+    echo "Error: craftos execution timed out after 10 seconds."
+    exit 1
+fi


### PR DESCRIPTION
This adds CI that builds the latest dev release on every commit, and a separate release pipeline for manually triggered releases. The installer is also updated to automatically download the latest release, feel free to create your own paste with the installer and replace it.

Oh, and you'll need to run the `Stable Release` action with version `1.3.34-katze` after merging, otherwise the installer wont work.